### PR TITLE
Bump pypy from 3.8 to 3.9 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,7 @@ jobs:
       fail-fast: false
       matrix:
         # We only test on the lowest and highest supported PyPy versions
-        python-version: ["pypy3.8", "pypy3.10"]
+        python-version: ["pypy3.9", "pypy3.10"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.1.2


### PR DESCRIPTION
Pypy on its 3.8 version is no longer officially supported and it causes random segmentation faults when tests are run. Since testing is performed on the lowest/highest supported versions, it is being bumped to 3.9.
